### PR TITLE
SCRUM-28 Update scheduling page links

### DIFF
--- a/choose_schedule.html
+++ b/choose_schedule.html
@@ -14,11 +14,12 @@
         </div>
         <ul class="nav-links">
             <li class="nav-item"><a href="#" data-page="home">Home</a></li>
-            <li class="nav-item"><a href="#" data-page="devices">Devices</a></li>
-            <li class="nav-item"><a href="#" data-page="products">Products</a></li>
-            <li class="nav-item"><a href="#" data-page="about">About</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
             <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
             <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/createschedule.html
+++ b/createschedule.html
@@ -45,7 +45,6 @@
         <section id="home" class="page active">
             <h1>Create a schedule</h1>
             <p>Create a new feeding schedule for your pet (or edit an existing one)</p>
-            <p style="color: red;"><strong>Please note: Pet Presets coming soon!</strong></p>
             <p><hr /></p>
 			<form action="submit_schedule.js" method="post">
 				<p>Enter schedule name: <input name="schedule_name" type="text" /></p>

--- a/createschedule.html
+++ b/createschedule.html
@@ -28,11 +28,12 @@
         </div>
         <ul class="nav-links">
             <li class="nav-item"><a href="#" data-page="home">Home</a></li>
-            <li class="nav-item"><a href="#" data-page="devices">Devices</a></li>
-            <li class="nav-item"><a href="#" data-page="products">Products</a></li>
-            <li class="nav-item"><a href="#" data-page="about">About</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
             <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
             <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/schedule.html
+++ b/schedule.html
@@ -14,11 +14,12 @@
         </div>
         <ul class="nav-links">
             <li class="nav-item"><a href="#" data-page="home">Home</a></li>
-            <li class="nav-item"><a href="#" data-page="devices">Devices</a></li>
-            <li class="nav-item"><a href="#" data-page="products">Products</a></li>
-            <li class="nav-item"><a href="#" data-page="about">About</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
             <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
             <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>
@@ -36,17 +37,12 @@
     				<button>Create schedule</button>
 			</a>
 			<p>&nbsp;</p>
-			<p>Edit existing schedule</p>
+			<p>Edit or Delete existing schedule</p>
 			<p>
 			<a href="choose_schedule.html">
-    				<button>Edit schedule</button>
+    				<button>Edit/Delete schedule</button>
 			</a>
-			<p style="color: red;">Please note- Editing functionality has not been implemented yet!</p>
-			<p>Delete schedule</p>
-			<a href="choose_schedule.html">
-				<button>Delete schedule</button>
-			</a>
-			<p style="color: red;">Please note- Deleting functionality has not been implemented yet!</p>
+			<p style="color: red;">Please note- Editing/Deleting functionality has not been implemented yet!</p>
 	</section>	
     </main>
 


### PR DESCRIPTION
Updated scheduling page links to be consistent with the home page (index.html). Also a few minor changes to the scheduling pages were made as well. Here they are:
- The pet preset text has been removed as it will not be implemented.
- The delete button has been removed from schedule.html. Instead, it will be in choose_schedule.html
- Changed the edit schedule button to **edit/delete schedule** to reflect this change in design

Merging this pull request will close SCRUM-28 (Fix links on scheduling pages) on Jira.