### PR TITLE
SCRUM-33 Update links on all pages

### DIFF
--- a/choose_schedule.html
+++ b/choose_schedule.html
@@ -13,13 +13,13 @@
                 <img src="images/img5.webp" alt="Dog">  </a>
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/" data-page="https://capiibarkbytes.github.io/">Home</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
-            <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" target="_self">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/createschedule.html
+++ b/createschedule.html
@@ -59,13 +59,13 @@
                 <img src="images/img5.webp" alt="Dog">  </a>
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/" data-page="https://capiibarkbytes.github.io/">Home</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
-            <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" target="_self">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
                 4d0ee1f0cb&w=900" alt="Dog"-->
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="index.html" data-page="home" target="_self">Home</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="schedule" target="_self">Schedule</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="login" target="_self">Login</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="signup" target="_self">Sign Up</a></li>
-            <li class="nav-item"><a href="#" data-page="contact" target="_self">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account" target="_self">My Account</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand" target="_self">ON DEMAND</a></li>
+            <li class="nav-item"><a href="index.html" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" target="_self">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
                 4d0ee1f0cb&w=900" alt="Dog"-->
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="index.html" data-page="home">Home</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
-            <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
+            <li class="nav-item"><a href="index.html" data-page="home" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="schedule" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="login" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="signup" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" data-page="contact" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" data-page="account" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand" target="_self">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>

--- a/onDemand.html
+++ b/onDemand.html
@@ -14,13 +14,13 @@
             </a>
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="index.html" data-page="home">Home</a></li>
-            <li class="nav-item"><a href="#" data-page="devices">Devices</a></li>
-            <li class="nav-item"><a href="#" data-page="products">Products</a></li>
-            <li class="nav-item"><a href="#" data-page="about">About</a></li>
-            <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
-            <li class="nav-item"><a href="#" data-page="onDemand">ON DEMAND</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/index.html" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" target="_self">ON DEMAND</a></li>
             </ul>
         <div class="burger">
             <div class="line1"></div>

--- a/schedule.html
+++ b/schedule.html
@@ -21,13 +21,13 @@
                 <img src="images/img5.webp" alt="Dog">  </a>
         </div>
         <ul class="nav-links">
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/index.html" data-page="https://capiibarkbytes.github.io">Home</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" data-page="https://capiibarkbytes.github.io/schedule">Schedule</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" data-page="https://capiibarkbytes.github.io/login.html">Login</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" data-page="https://capiibarkbytes.github.io/singup.html">Sign Up</a></li>
-            <li class="nav-item"><a href="#" data-page="contact">Contact</a></li>
-            <li class="nav-item"><a href="#" data-page="account">My Account</a></li>
-            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" data-page="On Demand">ON DEMAND</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/index.html" target="_self">Home</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/schedule.html" target="_self">Schedule</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/login.html" target="_self">Login</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/signup.html" target="_self">Sign Up</a></li>
+            <li class="nav-item"><a href="#" target="_self">Contact</a></li>
+            <li class="nav-item"><a href="#" target="_self">My Account</a></li>
+            <li class="nav-item"><a href="https://capiibarkbytes.github.io/onDemand.html" target="_self">ON DEMAND</a></li>
         </ul>
         <div class="burger">
           <div class="line1"></div>


### PR DESCRIPTION
This pull request changes all the links on the main navigation bars of all webpages to **prevent the opening of new tabs upon click**. Merging this closes SCRUM-33. Also, the "data-page" ID tag has been removed on all the links as they are used for Javascript purposes. However we don't have any Javascript files that are used for this sort of purpose.